### PR TITLE
:recycle: refactor the BigInteger methods, turn their number param to bigint

### DIFF
--- a/lib/BigInteger/index.d.ts
+++ b/lib/BigInteger/index.d.ts
@@ -3,15 +3,34 @@ import String from "../String";
 
 declare namespace BigInteger {
 
-export type IsNegative<A extends number> = Integer.IsNegative<A>; // Non-template-literal method
-export type IsPositive<A extends number> = Integer.IsPositive<A>;
-export type IsZero<A extends number> = Integer.IsZero<A>;
-export type Opposite<A extends number> = Integer.Opposite<A>;
-export type Eq<A extends number, B extends number> = Integer.Eq<A, B>;
+export type ToString<A extends bigint> = `${A}`;
+
+export type IsNegative<A extends bigint>
+  = `${A}` extends `-${infer OA extends bigint}` ? true : false;
+
+export type IsPositive<A extends bigint>
+  = IsNegative<A> extends false
+    ? A extends 0n
+      ? false
+      : true
+    : false;
+
+export type IsZero<A extends bigint> = A extends 0n ? true : false;
+
+export type Opposite<A extends bigint>
+  = IsZero<A> extends true
+    ? 0
+    : `${A}` extends `-${infer OA extends bigint}`
+      ? OA
+      : `-${A}` extends `${infer OA extends bigint}`
+        ? OA
+        : never;
+
+export type Eq<A extends bigint, B extends bigint> = A extends B ? true : false;
 
 export type Lower<
-  A extends number, 
-  B extends number,
+  A extends bigint, 
+  B extends bigint,
   AS extends string = `${A}`,
   BS extends string = `${B}`,
   Count extends number = 0,
@@ -39,9 +58,13 @@ export type Lower<
           : never
     : IsNegative<A> extends true
       ? IsNegative<B> extends true
-        ? Lower<Opposite<A>, Opposite<B>> extends true
-          ? false
-          : true
+        ? Opposite<A> extends bigint
+          ? Opposite<B> extends bigint
+            ? Lower<Opposite<A>, Opposite<B>> extends true
+              ? false
+              : true
+            : never
+          : never
         : true
       : IsZero<A> extends true
         ? IsNegative<B> extends true

--- a/lib/BigInteger/index.d.ts
+++ b/lib/BigInteger/index.d.ts
@@ -3,11 +3,42 @@ import String from "../String";
 
 declare namespace BigInteger {
 
+/**
+ * The behavior of this method is same with JavaScript `BigInt.prototype.toString`,
+ * this method will delete the `n` at the end of BigInteger.
+ * 
+ * @param A The bigint to convert to string
+ * 
+ * @example
+ * type BigInt1 = BigInteger.ToString<8n>;    // "8"
+ * type BigInt2 = BigInteger.ToString<-128n>; // "-128"
+ * type BigInt3 = BigInteger.ToString<0n>;    // "0"
+ */
 export type ToString<A extends bigint> = `${A}`;
 
+/**
+ * This method checks if a bigint is negative.
+ * 
+ * @param A The bigint to check if is negative.
+ * 
+ * @example
+ * type Is1 = BigInteger.IsNegative<1n>;  // => false
+ * type Is2 = BigInteger.IsNegative<0n>;  // => false
+ * type Is3 = BigInteger.IsNegative<-2n>; // => true
+ */
 export type IsNegative<A extends bigint>
   = `${A}` extends `-${infer OA extends bigint}` ? true : false;
 
+/**
+ * This method checks if a bigint is positive.
+ * 
+ * @param A The bigint to check if is positive.
+ * 
+ * @example
+ * type Is1 = BigInteger.IsPositive<1n>;  // => true
+ * type Is2 = BigInteger.IsPositive<0n>;  // => false
+ * type Is3 = BigInteger.IsPositive<-2n>; // => false
+ */
 export type IsPositive<A extends bigint>
   = IsNegative<A> extends false
     ? A extends 0n
@@ -15,8 +46,28 @@ export type IsPositive<A extends bigint>
       : true
     : false;
 
+/**
+ * This method checks if a bigint is zero.
+ * 
+ * @param A The bigint to check if is zero.
+ * 
+ * @example
+ * type Is1 = BigInteger.IsZero<1n>;  // => false
+ * type Is2 = BigInteger.IsZero<0n>;  // => true
+ * type Is3 = BigInteger.IsZero<-2n>; // => false
+ */
 export type IsZero<A extends bigint> = A extends 0n ? true : false;
 
+/**
+ * This method gets the opposite of a bigint.
+ * 
+ * @param A The bigint to be got opposite.
+ * 
+ * @example
+ * type Opposite1 = BigInteger.Opposite<3n>;  // -3n
+ * type Opposite2 = BigInteger.Opposite<0n>;  // 0n
+ * type Opposite3 = BigInteger.Opposite<-2n>; // 2n
+ */
 export type Opposite<A extends bigint>
   = IsZero<A> extends true
     ? 0
@@ -26,8 +77,34 @@ export type Opposite<A extends bigint>
         ? OA
         : never;
 
+/**
+ * This method checks if a bigint is equal to another.
+ * 
+ * @param A `a` in `a == b` expression.
+ * @param B `b` in `a == b` expression.
+ * 
+ * @example
+ * type Eq1 = BigInteger.Eq<3n, 3n>;    // true
+ * type Eq2 = BigInteger.Eq<0n, 1n>;    // false
+ * type Eq3 = BigInteger.Eq<-2n, -2n>;  // true
+ */
 export type Eq<A extends bigint, B extends bigint> = A extends B ? true : false;
 
+/**
+ * This method checks if a bigint is lower than another.
+ * 
+ * @param A `a` in `if a < b` expression.
+ * @param B `b` in `if a < b` expression.
+ * 
+ * @example
+ * type Lower1 = BigInteger.Lower<-34n, 2n>;   // true
+ * type Lower2 = BigInteger.Lower<0n, 2n>;     // true
+ * type Lower3 = BigInteger.Lower<23n, 2n>;    // false
+ * type Lower4 = BigInteger.Lower<-34n, -4n>;  // true
+ * type Lower5 = BigInteger.Lower<-4n, -4n>;   // false
+ * type Lower6 = BigInteger.Lower<4n, 4n>;     // false
+ * type Lower7 = BigInteger.Lower<0n, 0n>;     // false
+ */
 export type Lower<
   A extends bigint, 
   B extends bigint,

--- a/lib/BigInteger/index.d.ts
+++ b/lib/BigInteger/index.d.ts
@@ -22,9 +22,9 @@ export type ToString<A extends bigint> = `${A}`;
  * @param A The bigint to check if is negative.
  * 
  * @example
- * type Is1 = BigInteger.IsNegative<1n>;  // => false
- * type Is2 = BigInteger.IsNegative<0n>;  // => false
- * type Is3 = BigInteger.IsNegative<-2n>; // => true
+ * type Is1 = BigInteger.IsNegative<1n>;  // false
+ * type Is2 = BigInteger.IsNegative<0n>;  // false
+ * type Is3 = BigInteger.IsNegative<-2n>; // true
  */
 export type IsNegative<A extends bigint>
   = `${A}` extends `-${infer OA extends bigint}` ? true : false;
@@ -35,9 +35,9 @@ export type IsNegative<A extends bigint>
  * @param A The bigint to check if is positive.
  * 
  * @example
- * type Is1 = BigInteger.IsPositive<1n>;  // => true
- * type Is2 = BigInteger.IsPositive<0n>;  // => false
- * type Is3 = BigInteger.IsPositive<-2n>; // => false
+ * type Is1 = BigInteger.IsPositive<1n>;  // true
+ * type Is2 = BigInteger.IsPositive<0n>;  // false
+ * type Is3 = BigInteger.IsPositive<-2n>; // false
  */
 export type IsPositive<A extends bigint>
   = IsNegative<A> extends false
@@ -52,9 +52,9 @@ export type IsPositive<A extends bigint>
  * @param A The bigint to check if is zero.
  * 
  * @example
- * type Is1 = BigInteger.IsZero<1n>;  // => false
- * type Is2 = BigInteger.IsZero<0n>;  // => true
- * type Is3 = BigInteger.IsZero<-2n>; // => false
+ * type Is1 = BigInteger.IsZero<1n>;  // false
+ * type Is2 = BigInteger.IsZero<0n>;  // true
+ * type Is3 = BigInteger.IsZero<-2n>; // false
  */
 export type IsZero<A extends bigint> = A extends 0n ? true : false;
 

--- a/lib/BigInteger/index.d.ts
+++ b/lib/BigInteger/index.d.ts
@@ -70,7 +70,7 @@ export type IsZero<A extends bigint> = A extends 0n ? true : false;
  */
 export type Opposite<A extends bigint>
   = IsZero<A> extends true
-    ? 0
+    ? 0n
     : `${A}` extends `-${infer OA extends bigint}`
       ? OA
       : `-${A}` extends `${infer OA extends bigint}`

--- a/test/lib-BigInteger.test.ts
+++ b/test/lib-BigInteger.test.ts
@@ -8,6 +8,17 @@ import BigInteger from "../lib/BigInteger";
 import { Equal, Expect } from "../utils";
 
 type CaseLibBigInteger = [
+  // BigInteger.Eq
+  Expect<Equal<BigInteger.Eq<0n, 0n>, true>>,
+  Expect<Equal<BigInteger.Eq<-12n, -12n>, true>>,
+  Expect<Equal<BigInteger.Eq<23n, 22n>, false>>,
+  Expect<Equal<BigInteger.Eq<23n, -23n>, false>>,
+
+  // BigInteger.Opposite
+  Expect<Equal<BigInteger.Opposite<0n>, 0n>>,
+  Expect<Equal<BigInteger.Opposite<23n>, -23n>>,
+  Expect<Equal<BigInteger.Opposite<-12n>, 12n>>,
+
   // BigInteger.Lower
   Expect<Equal<BigInteger.Lower<23n, 123n>, true>>,
   Expect<Equal<BigInteger.Lower<23n, 23n>, false>>,
@@ -17,5 +28,25 @@ type CaseLibBigInteger = [
   Expect<Equal<BigInteger.Lower<0n, 0n>, false>>,
   Expect<Equal<BigInteger.Lower<-2n, -2n>, false>>,
   Expect<Equal<BigInteger.Lower<12345n, 12345n>, false>>,
+
+  // BigInteger.ToString
+  Expect<Equal<BigInteger.ToString<2n>, "2">>,
+  Expect<Equal<BigInteger.ToString<-2n>, "-2">>,
+  Expect<Equal<BigInteger.ToString<0n>, "0">>,
+
+  // BigInteger.IsZero
+  Expect<Equal<BigInteger.IsZero<0n>, true>>,
+  Expect<Equal<BigInteger.IsZero<29n>, false>>,
+  Expect<Equal<BigInteger.IsZero<-2n>, false>>,
+
+  // BigInteger.IsNegative
+  Expect<Equal<BigInteger.IsNegative<-23n>, true>>,
+  Expect<Equal<BigInteger.IsNegative<26n>, false>>,
+  Expect<Equal<BigInteger.IsNegative<0n>, false>>,
+
+  // BigInteger.IsPositive
+  Expect<Equal<BigInteger.IsPositive<90n>, true>>,
+  Expect<Equal<BigInteger.IsPositive<0n>, false>>,
+  Expect<Equal<BigInteger.IsPositive<-8n>, false>>,
 
 ]

--- a/test/lib-BigInteger.test.ts
+++ b/test/lib-BigInteger.test.ts
@@ -9,13 +9,13 @@ import { Equal, Expect } from "../utils";
 
 type CaseLibBigInteger = [
   // BigInteger.Lower
-  Expect<Equal<BigInteger.Lower<23, 123>, true>>,
-  Expect<Equal<BigInteger.Lower<23, 23>, false>>,
-  Expect<Equal<BigInteger.Lower<1234, 1235>, true>>,
-  Expect<Equal<BigInteger.Lower<-123, 90>, true>>,
-  Expect<Equal<BigInteger.Lower<123, -90>, false>>,
-  Expect<Equal<BigInteger.Lower<0, 0>, false>>,
-  Expect<Equal<BigInteger.Lower<-2, -2>, false>>,
-  Expect<Equal<BigInteger.Lower<12345, 12345>, false>>,
+  Expect<Equal<BigInteger.Lower<23n, 123n>, true>>,
+  Expect<Equal<BigInteger.Lower<23n, 23n>, false>>,
+  Expect<Equal<BigInteger.Lower<1234n, 1235n>, true>>,
+  Expect<Equal<BigInteger.Lower<-123n, 90n>, true>>,
+  Expect<Equal<BigInteger.Lower<123n, -90n>, false>>,
+  Expect<Equal<BigInteger.Lower<0n, 0n>, false>>,
+  Expect<Equal<BigInteger.Lower<-2n, -2n>, false>>,
+  Expect<Equal<BigInteger.Lower<12345n, 12345n>, false>>,
 
 ]

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -26,7 +26,7 @@ declare -A test_cases=(
   ["Array.CreateArrayFromLength"]="2:[undefined,undefined] 3|string:[string,string,string] 0:[] -1:[]"
   ["Array.At"]="[1,2,3]|2:3 [1,2,3,4]|0|:1"
 
-  ["BigInteger.Lower"]="23|123:true 23|23:false 1234|1235:true -123|90:true 123|-90:false 0|0:false -2|-2:false 12345|12345:false"
+  ["BigInteger.Lower"]="23n|123n:true 23n|23n:false 1234n|1235n:true -123n|90n:true 123n|-90n:false 0n|0n:false -2n|-2n:false 12345n|12345n:false"
 
   ["String.Length"]="\"abs\":3 \"\":0 \"2222_2222_2222_2222_2222\":24"
   ["String.At"]="\"123456789\"|0:\"1\" \"123456789\"|2:\"3\" \"123456789\"|-3:\"7\" \"123456789\"|100:never"

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -26,6 +26,12 @@ declare -A test_cases=(
   ["Array.CreateArrayFromLength"]="2:[undefined,undefined] 3|string:[string,string,string] 0:[] -1:[]"
   ["Array.At"]="[1,2,3]|2:3 [1,2,3,4]|0|:1"
 
+  ["BigInteger.ToString"]="2n:\"2\" -2n:\"-2\" 0n:\"0\""
+  ["BigInteger.IsNegative"]="-23n:true 26n:false 0n:false"
+  ["BigInteger.IsPositive"]="90n:true 0n:false -8n:false"
+  ["BigInteger.IsZero"]="0n:true 29n:false -2n:false"
+  ["BigInteger.Opposite"]="0n:0n 23n:-23n -12n:12n"
+  ["BigInteger.Eq"]="0n|0n:true -12n|-12n:true 23n|22n:false 23n|-23n:false"
   ["BigInteger.Lower"]="23n|123n:true 23n|23n:false 1234n|1235n:true -123n|90n:true 123n|-90n:false 0n|0n:false -2n|-2n:false 12345n|12345n:false"
 
   ["String.Length"]="\"abs\":3 \"\":0 \"2222_2222_2222_2222_2222\":24"


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

This PR refactors the type functions in `BigInteger` namespace, turn the number type parameter to bigint. Like this:

``` ts
export type IsPositive<A extends bigint>
  = IsNegative<A> extends false
    ? A extends 0n
      ? false
      : true
    : false;
```

This PR also changes corresponding test scripts, and `BigInteger.Lower` has passed all tests. We can add more tests on `BigInteger.Eq`, `BigInteger.Opacity` etc.

### 🌴 PR Type

<!-- Please check the PR type -->

+ [ ] ✨ Feature
+ [x] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Change log

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [ ] I have updated the changelog/next.md with my changes.