### PR TITLE
:sparkles: add `Boolean.MultipleAnd` and `Boolean.MultipleOr` methods

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -17,6 +17,12 @@
   + `Array.Concat<A, B>`
   + `Array.Fill<Arr, V, Start?, End?>`
 
+### 2025-06-07 (feature/boolean-methods → main)
+
++ Add two new methods of multiple params of `Boolean` namespace:
+  + `Boolean.MultipleAnd<[boolean]>`
+  + `Boolean.MultipleOr<[boolean]>`
+
 ## ⚡ Improvements
 
 ## 🐦‍🔥 No longer broken

--- a/lib/Boolean/index.d.ts
+++ b/lib/Boolean/index.d.ts
@@ -83,6 +83,20 @@ export type Nand<A extends boolean, B extends boolean> = Not<And<A, B>>;
  */
 export type Nor<A extends boolean, B extends boolean> = Not<Or<A, B>>;
 
+/**
+ * This method is `N` element version of `And`, it returns the value of expression
+ * `a_1 && a_2 && ... a_n`
+ * 
+ * @param BArr The array of booleans `a_1`, `a_2`, ..., `a_n`
+ * @returns The value of expression `a_1 && a_2 && ... && a_n`.
+ */
+export type MultipleAnd<BArr extends boolean[]>
+  = BArr extends [infer F extends boolean, ...infer Rest extends boolean[]]
+    ? F extends false
+      ? false
+      : MultipleAnd<Rest>
+    : true
+
 }
 
 export default Boolean;

--- a/lib/Boolean/index.d.ts
+++ b/lib/Boolean/index.d.ts
@@ -97,6 +97,20 @@ export type MultipleAnd<BArr extends boolean[]>
       : MultipleAnd<Rest>
     : true
 
+/**
+ * This method is `N` element version of `Or`, it returns the value of expression
+ * `a_1 || a_2 || ... a_n`
+ * 
+ * @param BArr The array of booleans `a_1`, `a_2`, ..., `a_n`
+ * @returns The value of expression `a_1 || a_2 || ... || a_n`.
+ */
+export type MultipleOr<BArr extends boolean[]>
+  = BArr extends [infer F extends boolean, ...infer Rest extends boolean[]]
+    ? F extends true
+      ? true
+      : MultipleOr<Rest>
+    : false;
+
 }
 
 export default Boolean;

--- a/test/lib-Boolean.test.ts
+++ b/test/lib-Boolean.test.ts
@@ -14,6 +14,11 @@ type CaseLibBoolean = [
   Expect<Equal<Boolean.Nand<true, false>, true>>,
   Expect<Equal<Boolean.Nand<true, true>, false>>,
 
+  // Boolean.MultipleAnd
+  Expect<Equal<Boolean.MultipleAnd<[true,true,true]>, true>>,
+  Expect<Equal<Boolean.MultipleAnd<[true,false,true]>, false>>,
+  Expect<Equal<Boolean.MultipleAnd<[false,false,false]>, false>>,
+
   // Boolean.And
   Expect<Equal<Boolean.And<false, false>, false>>,
   Expect<Equal<Boolean.And<false, true>, false>>,
@@ -25,6 +30,11 @@ type CaseLibBoolean = [
   Expect<Equal<Boolean.Nor<false, true>, false>>,
   Expect<Equal<Boolean.Nor<true, false>, false>>,
   Expect<Equal<Boolean.Nor<true, true>, false>>,
+
+  // Boolean.MultipleOr
+  Expect<Equal<Boolean.MultipleOr<[true,true,true]>, true>>,
+  Expect<Equal<Boolean.MultipleOr<[true,false,false]>, true>>,
+  Expect<Equal<Boolean.MultipleOr<[false,false,false]>, false>>,
 
   // Boolean.Or
   Expect<Equal<Boolean.Or<false, false>, false>>,

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -48,6 +48,8 @@ declare -A test_cases=(
   ["Boolean.Nor"]="false:true true:false"
   ["Boolean.Nand"]="false|false:true false|true:true true|false:true true|true:false"
   ["Boolean.Nor"]="false|false:true false|true:false true|false:false true|true:false"
+  ["Boolean.MultipleAnd"]="[true,true,true]:true [true,false,true]:false [false,false,false]:false"
+  ["Boolean.MultipleOr"]="[true,true,true]:true [true,false,false]:true [false,false,false]:false"
 )
 
 function repeat {


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

This PR adds `Boolean.MultipleAnd` and `Boolean.MultipleOr` methods to `Boolean` namespace, the spread syntax is simulated by `tuple type`. And its usage is like this:

``` ts
type A = Boolean.MultipleAnd<[
  Integer.Lower<2, 1>,
  Integer.IsNegative<-2>,
  Integer.Eq<Arr["length"], 3>
]>
```

### 🌴 PR Type

<!-- Please check the PR type -->

+ [x] ✨ Feature
+ [ ] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Change log

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [x] I have updated the changelog/next.md with my changes.