### PR TITLE
:bug: fix the problem of issue #6, now pass `[]` and a negative number to `Array.At` gets `never`

### DIFF
--- a/lib/Array/index.d.ts
+++ b/lib/Array/index.d.ts
@@ -53,17 +53,19 @@ export type At<
   Arr extends unknown[],
   N extends number, 
   Count extends unknown[] = []
-> = Integer.IsNegative<N> extends true
-  ? Integer.Add<N, Arr["length"]> extends number
-    ? At<Arr, Integer.Add<N, Arr["length"]>, Count>
-    : never
-  : Count["length"] extends N
-    ? Arr extends [infer F, ...infer Rest]
-      ? F
+> = Integer.Eq<Arr["length"], 0> extends true
+  ? never
+  : Integer.IsNegative<N> extends true
+    ? Integer.Add<N, Arr["length"]> extends number
+      ? At<Arr, Integer.Add<N, Arr["length"]>, Count>
       : never
-    : Arr extends [infer F, ...infer Rest]
-      ? At<Rest, N, [...Count, F]>
-      : never;
+    : Count["length"] extends N
+      ? Arr extends [infer F, ...infer Rest]
+        ? F
+        : never
+      : Arr extends [infer F, ...infer Rest]
+        ? At<Rest, N, [...Count, F]>
+        : never;
 
 /**
  * Unlike `Array.prototype.concat` method, it cannot receive unlimited type

--- a/test/lib-Array.test.ts
+++ b/test/lib-Array.test.ts
@@ -47,5 +47,8 @@ type CaseLibArray = [
   // Array.At
   Expect<Equal<Array.At<[1,2,3], 2>, 3>>,
   Expect<Equal<Array.At<[1,2,3,4], 0>, 1>>,
+  Expect<Equal<Array.At<[], 1>, never>>,
+  Expect<Equal<Array.At<[], -1>, never>>,
+  Expect<Equal<Array.At<[], 0>, never>>,
 
 ]

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -24,7 +24,7 @@ declare -A test_cases=(
   ["Integer.IsEven"]="1:false 0:true -22:true 19:false"
 
   ["Array.CreateArrayFromLength"]="2:[undefined,undefined] 3|string:[string,string,string] 0:[] -1:[]"
-  ["Array.At"]="[1,2,3]|2:3 [1,2,3,4]|0|:1"
+  ["Array.At"]="[1,2,3]|2:3 [1,2,3,4]|0|:1 []|1:never []|-1:never []|0:never"
   ["Array.Concat"]="[1,2,3]|[2,3,1]:[1,2,3,2,3,1]"
   ["Array.Fill"]="[1,2,3]|\"3\":[\"3\",\"3\",\"3\"] [0,9,1]|\"1\"|1|2:[0,\"1\",1] [\"head\",9,1]|true|1:[\"head\",true,true] [1,2,3]|\"3\"|2|1:[1,2,3] [1,2,3]|\"3\"|-4|2:[\"3\",\"3\",3] [1,2,3]|\"3\"|-2|3:[1,\"3\",\"3\"] [1,2,3]|\"3\"|7|2:[1,2,3] [1,2,3]|\"3\"|1|-1:[1,\"3\",3]"
   ["Array.IsFlatten"]="[1,2,3]:true []:true [[]]:false [1,[2],3]:false [[],1,2]:false [1,[1,2,[]],undefined]:false"


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

Original implementation of `Array.At` method is like this:

``` ts
export type At<
  Arr extends unknown[],
  N extends number, 
  Count extends unknown[] = []
> = Integer.IsNegative<N> extends true
  ? Integer.Add<N, Arr["length"]> extends number
    ? At<Arr, Integer.Add<N, Arr["length"]>, Count>
    /** @remark When the length of `Arr` is 0, then the second parameter passed 
      * to next recursion is still negative and will recurse infinitely because 
      * `N` will never get positive 
      */
    : never
  : Count["length"] extends N
    ? Arr extends [infer F, ...infer Rest]
      ? F
      : never
    : Arr extends [infer F, ...infer Rest]
      ? At<Rest, N, [...Count, F]>
      : never;
```

So we only need to check if the first parameter is an empty array. If so, we return `never` whatever.

### 🌴 PR Type

<!-- Please check the PR type -->

+ [ ] ✨ Feature
+ [x] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 🔥 Linked issues

This PR solves issue #6

### 👾 Additional context

### ⛳ Change log

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [ ] I have updated the changelog/next.md with my changes.