### PR TITLE
:sparkles: feat(array-methods): add `Array.Reverse` and `Array.Shift` methods

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -48,6 +48,12 @@
 + Add a new method of `Array` namespace:
   + `Array.LastIndexOf<Arr, T>`
 
+### 2025-07--09 (feature/array-methods → main)
+
++ Add two new methods of `Array` namespace:
+  + `Array.Reverse<Arr>`
+  + `Array.Shift<Arr, Mode>`
+
 ## ⚡ Improvements
 
 ## 🐦‍🔥 No longer broken

--- a/lib/Array/index.d.ts
+++ b/lib/Array/index.d.ts
@@ -357,6 +357,23 @@ export type Pop<
  */
 export type Push<Arr extends unknown[], E extends unknown> = [...Arr, E];
 
+/**
+ * This method is like `Array.prototype.revers`, it reverses the array.
+ * 
+ * @param Arr The array to be reversed.
+ * @param Result The array to store the final reversed result in the process
+ * procedure.
+ * @returns The reversed array.
+ * 
+ * @example
+ * type Reverse1 = Array.Reverse<[1, 2, 3]>;  // [3, 2, 1]
+ * type Reverse2 = Array.Reverse<[]>;         // []
+ */
+export type Reverse<Arr extends unknown[], Result extends unknown[] = []>
+  = Arr extends [infer F, ...infer Rest]
+    ? Reverse<Rest, [F, ...Result]>
+    : Result;
+
 }
 
 export default Array;

--- a/lib/Array/index.d.ts
+++ b/lib/Array/index.d.ts
@@ -392,10 +392,10 @@ export type Reverse<Arr extends unknown[], Result extends unknown[] = []>
  * type Shift2 = Array.Shift<[1], "get-rest">;  // []
  * type Shift3 = Array.Shift<[], "get-rest">;   // never
  * 
- * // "get-pop-element" mode
- * type Pop4 = Array.Pop<[1, 2, 3], "get-pop-element">; // 3
- * type Pop5 = Array.Pop<[1], "get-pop-element">;       // 1
- * type Pop6 = Array.Pop<[], "get-pop-element">;        // never
+ * // "get-shift-element" mode
+ * type Shift4 = Array.Shift<[1, 2, 3], "get-shift-element">; // 1
+ * type Shift5 = Array.Shift<[1], "get-shift-element">;       // 1
+ * type Shift6 = Array.Shift<[], "get-shift-element">;        // never
  */
 export type Shift<
   Arr extends unknown[],

--- a/lib/Array/index.d.ts
+++ b/lib/Array/index.d.ts
@@ -25,7 +25,7 @@ declare namespace Array {
 export type CreateArrayFromLength<
   L extends number, 
   T extends unknown = undefined, 
-  Count extends T[] = []
+  Count extends unknown[] = []
 > = Integer.IsNegative<L> extends true
   ? []
   : Count["length"] extends L
@@ -53,7 +53,7 @@ export type CreateArrayFromLength<
 export type At<
   Arr extends unknown[],
   N extends number, 
-  Count extends unknown[] = []
+  Count extends 0[] = []
 > = Integer.Eq<Arr["length"], 0> extends true
   ? never
   : Integer.IsNegative<N> extends true
@@ -65,7 +65,7 @@ export type At<
         ? F
         : never
       : Arr extends [infer F, ...infer Rest]
-        ? At<Rest, N, [...Count, F]>
+        ? At<Rest, N, [...Count, 0]>
         : never;
 
 /**

--- a/lib/Array/index.d.ts
+++ b/lib/Array/index.d.ts
@@ -374,6 +374,43 @@ export type Reverse<Arr extends unknown[], Result extends unknown[] = []>
     ? Reverse<Rest, [F, ...Result]>
     : Result;
 
+/**
+ * This method is like `Array.prototype.shift`, but it cannot change the array itself
+ * (types are not references). So we can use `Mode` to determine whether this method
+ * returns the rest part or returns the shifted element.
+ * 
+ * @param Arr The array to be shifted.
+ * @param Mode If you choose mode `"get-rest"`, this method will return the rest
+ * part of array. If you choose mode `"get-shift-element"`, this method will return the
+ * shifted element. Default to `"get-rest"`
+ * @returns When `Mode` is `"get-rest"`, returns the rest part. When `Mode` is `"get-
+ * shift-element"`, returns the shifted element.
+ * 
+ * @example
+ * // "get-rest" mode
+ * type Shift1 = Array.Shift<[1, 2, 3]>;        // [2, 3]
+ * type Shift2 = Array.Shift<[1], "get-rest">;  // []
+ * type Shift3 = Array.Shift<[], "get-rest">;   // never
+ * 
+ * // "get-pop-element" mode
+ * type Pop4 = Array.Pop<[1, 2, 3], "get-pop-element">; // 3
+ * type Pop5 = Array.Pop<[1], "get-pop-element">;       // 1
+ * type Pop6 = Array.Pop<[], "get-pop-element">;        // never
+ */
+export type Shift<
+  Arr extends unknown[],
+  Mode extends 
+    | "get-rest"
+    | "get-shift-element"
+    = "get-rest"
+> = Mode extends "get-rest" 
+  ? Arr extends [infer ShiftElement, ...infer Rest]
+    ? Rest
+    : never
+  : Arr extends [infer ShiftElement, ...infer Rest]
+    ? ShiftElement
+    : never;
+
 }
 
 export default Array;

--- a/test/lib-Boolean.test.ts
+++ b/test/lib-Boolean.test.ts
@@ -25,6 +25,10 @@ type CaseLibBoolean = [
   Expect<Equal<Boolean.And<true, false>, false>>,
   Expect<Equal<Boolean.And<true, true>, true>>,
 
+  // Boolean.Not
+  Expect<Equal<Boolean.Not<false>, true>>,
+  Expect<Equal<Boolean.Not<true>, false>>,
+
   // Boolean.Nor
   Expect<Equal<Boolean.Nor<false, false>, true>>,
   Expect<Equal<Boolean.Nor<false, true>, false>>,

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -54,7 +54,7 @@ declare -A test_cases=(
 
   ["Boolean.And"]="false‖false∷false false‖true∷false true‖false∷false true‖true∷true"
   ["Boolean.Or"]="false‖false∷false false‖true∷true true‖false∷true true‖true∷true"
-  ["Boolean.Nor"]="false∷true true∷false"
+  ["Boolean.Not"]="false∷true true∷false"
   ["Boolean.Nand"]="false‖false∷true false‖true∷true true‖false∷true true‖true∷false"
   ["Boolean.Nor"]="false‖false∷true false‖true∷false true‖false∷false true‖true∷false"
   ["Boolean.MultipleAnd"]="[true,true,true]∷true [true,false,true]∷false [false,false,false]∷false"


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

This PR adds two new methods in `Array` namespace:
+ `Array.Reverse<Arr>`
+ `Array.Shift<Arr, Mode>`

### 🌴 PR Type

<!-- Please check the PR type -->

+ [x] ✨ Feature
+ [ ] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Change log

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [ ] I have updated the changelog/next.md with my changes.