### PR TITLE
:sparkles: feat(array-methods): add `Array.Unshift` method

### DIFF
--- a/changelog/next.md
+++ b/changelog/next.md
@@ -48,11 +48,16 @@
 + Add a new method of `Array` namespace:
   + `Array.LastIndexOf<Arr, T>`
 
-### 2025-07--09 (feature/array-methods → main)
+### 2025-07-09 (feature/array-methods → main)
 
 + Add two new methods of `Array` namespace:
   + `Array.Reverse<Arr>`
   + `Array.Shift<Arr, Mode>`
+
+### 2025-07-10 (feature/array-methods → main)
+
++ Add a new method of `Array` namespace:
+  + `Array.Unshift<Arr, E>`
 
 ## ⚡ Improvements
 

--- a/lib/Array/index.d.ts
+++ b/lib/Array/index.d.ts
@@ -411,6 +411,20 @@ export type Shift<
     ? ShiftElement
     : never;
 
+/**
+ * This method is like `Array.prototype.unshift`, it returns the new array that
+ * has been unshifted (which means pushing at the first) the new element.
+ * 
+ * @param Arr The array to be unshifted.
+ * @param E The new element to be unshifted into the `Arr`.
+ * @returns The new array.
+ * 
+ * @example
+ * type Unshift1 = Array.Unshift<[1, 2, 3], "1">; // ["1", 1, 2, 3]
+ * type Unshift2 = Array.Unshift<[], 1>;          // [1]
+ */
+export type Unshift<Arr extends unknown[], E extends unknown> = [E, ...Arr];
+
 }
 
 export default Array;

--- a/test/lib-Array.test.ts
+++ b/test/lib-Array.test.ts
@@ -17,6 +17,12 @@ type CaseLibArray = [
   Expect<Equal<Array.CreateArrayFromLength<0>, []>>,
   Expect<Equal<Array.CreateArrayFromLength<-1>, []>>,
 
+  // Array.Unshift
+  Expect<Equal<Array.Unshift<[1,2,3], 4>, [4,1,2,3]>>,
+  Expect<Equal<Array.Unshift<[], []>, [[]]>>,
+  Expect<Equal<Array.Unshift<[1], []>, [[],1]>>,
+  Expect<Equal<Array.Unshift<[], 1>, [1]>>,
+
   // Array.MultipleConcat
   Expect<Equal<Array.MultipleConcat<[[1,2,3],[4,2,3],[undefined,true]]>, [1,2,3,4,2,3,undefined,true]>>,
   Expect<Equal<Array.MultipleConcat<[[],[1],[],[2]]>, [1,2]>>,

--- a/test/lib-Array.test.ts
+++ b/test/lib-Array.test.ts
@@ -51,6 +51,13 @@ type CaseLibArray = [
   Expect<Equal<Array.IndexOf<[1,2,3], 4>, -1>>,
   Expect<Equal<Array.IndexOf<[1,2,1], 1>, 0>>,
 
+  // Array.Shift
+  Expect<Equal<Array.Shift<[1,2,3]>, [2,3]>>,
+  Expect<Equal<Array.Shift<["1"]>, []>>,
+  Expect<Equal<Array.Shift<[], "get-rest">, never>>,
+  Expect<Equal<Array.Shift<[1,2,3], "get-shift-element">, 1>>,
+  Expect<Equal<Array.Shift<["1"], "get-shift-element">, "1">>,
+
   // Array.IsFlatten
   Expect<Equal<Array.IsFlatten<[1,2,3]>, true>>,
   Expect<Equal<Array.IsFlatten<[]>, true>>,

--- a/test/lib-Array.test.ts
+++ b/test/lib-Array.test.ts
@@ -22,6 +22,11 @@ type CaseLibArray = [
   Expect<Equal<Array.Unshift<[], []>, [[]]>>,
   Expect<Equal<Array.Unshift<[1], []>, [[],1]>>,
   Expect<Equal<Array.Unshift<[], 1>, [1]>>,
+  Expect<Equal<Array.Unshift<[{a:1},{b:2}], {c:3}>, [{c:3},{a:1},{b:2}]>>,
+  Expect<Equal<Array.Unshift<[[1,2],[3,4]], [5,6]>, [[5,6],[1,2],[3,4]]>>,
+  Expect<Equal<Array.Unshift<[1|2,3], 4|5>, [4|5,1|2,3]>>,
+  Expect<Equal<Array.Unshift<[], {a:string,b:number}>, [{a:string,b:number}]>>,
+  Expect<Equal<Array.Unshift<[{x:number}], {y:boolean}>, [{y:boolean},{x:number}]>>,
 
   // Array.MultipleConcat
   Expect<Equal<Array.MultipleConcat<[[1,2,3],[4,2,3],[undefined,true]]>, [1,2,3,4,2,3,undefined,true]>>,

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -37,7 +37,7 @@ declare -A test_cases=(
   ["Array.Pop"]="[1,2,3]∷[1,2] [1]‖\"get-rest\"∷[] []‖\"get-rest\"∷never [1,2,3]‖\"get-pop-element\"∷3 [1]‖\"get-pop-element\"∷1 []‖\"get-pop-element\"∷never"
   ["Array.Push"]="[1,2,3]‖\"1\"∷[1,2,3,\"1\"] []‖1∷[1] []‖[]∷[[]]"
   ["Array.Shift"]="[1,2,3]∷[2,3] [\"1\"]∷[] []‖\"get-rest\"∷never [1,2,3]‖\"get-shift-element\"∷1 [\"1\"]‖\"get-shift-element\"∷\"1\""
-  ["Array.Unshift"]="[1,2,3]‖4∷[4,1,2,3] []‖[]∷[[]] [1]‖[]∷[[],1] []‖1∷[1]"
+  ["Array.Unshift"]="[1,2,3]‖4∷[4,1,2,3] []‖[]∷[[]] [1]‖[]∷[[],1] []‖1∷[1] [{a:1},{b:2}]‖{c:3}∷[{c:3},{a:1},{b:2}] [[1,2],[3,4]]‖[5,6]∷[[5,6],[1,2],[3,4]] [1|2,3]‖4|5∷[4|5,1|2,3] []‖{a:string,b:number}∷[{a:string,b:number}] [{x:number}]‖{y:boolean}∷[{y:boolean},{x:number}]"
 
   ["BigInteger.ToString"]="2n∷\"2\" -2n∷\"-2\" 0n∷\"0\""
   ["BigInteger.IsNegative"]="-23n∷true 26n∷false 0n∷false"

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -37,6 +37,7 @@ declare -A test_cases=(
   ["Array.Pop"]="[1,2,3]∷[1,2] [1]‖\"get-rest\"∷[] []‖\"get-rest\"∷never [1,2,3]‖\"get-pop-element\"∷3 [1]‖\"get-pop-element\"∷1 []‖\"get-pop-element\"∷never"
   ["Array.Push"]="[1,2,3]‖\"1\"∷[1,2,3,\"1\"] []‖1∷[1] []‖[]∷[[]]"
   ["Array.Shift"]="[1,2,3]∷[2,3] [\"1\"]∷[] []‖\"get-rest\"∷never [1,2,3]‖\"get-shift-element\"∷1 [\"1\"]‖\"get-shift-element\"∷\"1\""
+  ["Array.Unshift"]="[1,2,3]‖4∷[4,1,2,3] []‖[]∷[[]] [1]‖[]∷[[],1] []‖1∷[1]"
 
   ["BigInteger.ToString"]="2n∷\"2\" -2n∷\"-2\" 0n∷\"0\""
   ["BigInteger.IsNegative"]="-23n∷true 26n∷false 0n∷false"

--- a/test/script/lib-gen.sh
+++ b/test/script/lib-gen.sh
@@ -36,6 +36,7 @@ declare -A test_cases=(
   ["Array.Join"]="[1,2,3]∷\"1,2,3\" [-1,\".\",9]‖\"-\"∷\"-1-.-9\" [1,2,3]‖\"\"∷\"123\""
   ["Array.Pop"]="[1,2,3]∷[1,2] [1]‖\"get-rest\"∷[] []‖\"get-rest\"∷never [1,2,3]‖\"get-pop-element\"∷3 [1]‖\"get-pop-element\"∷1 []‖\"get-pop-element\"∷never"
   ["Array.Push"]="[1,2,3]‖\"1\"∷[1,2,3,\"1\"] []‖1∷[1] []‖[]∷[[]]"
+  ["Array.Shift"]="[1,2,3]∷[2,3] [\"1\"]∷[] []‖\"get-rest\"∷never [1,2,3]‖\"get-shift-element\"∷1 [\"1\"]‖\"get-shift-element\"∷\"1\""
 
   ["BigInteger.ToString"]="2n∷\"2\" -2n∷\"-2\" 0n∷\"0\""
   ["BigInteger.IsNegative"]="-23n∷true 26n∷false 0n∷false"


### PR DESCRIPTION
<!-- 

DO NOT IGNORE THE PR TEMPLATE!

Before submitting the PR, please make sure you do the following:

+ Check that there isn't already a PR that solves the problem the same way
  to avoid creating a duplicate.
+ Provide a description in this PR that addresses **what** the PR is solving,
  or reference issue that it solves (e.g. `fixes #1243`)
+ Ideally, include relevant tests that fail without this PR but pass with it.

 -->

### 📝 Description

<!-- Please insert your description here and provide especially info about the **what** this PR is solving -->

This PR introduces a new method of `Array` namespace:
+ `Array.Unshift<Arr, E>`

### 🌴 PR Type

<!-- Please check the PR type -->

+ [x] ✨ Feature
+ [ ] 🐛 Bugfix
+ [ ] 🚑 Hotfix
+ [ ] 💡 Doc comment
+ [ ] 🧪 Test
+ [ ] 📝 Document
+ [ ] 🐋 Other (please describe)

### 🔥 Linked issues

### 👾 Additional context

### ⛳ Change log

<!-- Please ensure the changelog/next.md is updated if this is a feature or hotfix -->

+ [x] I have updated the changelog/next.md with my changes.

## Summary by Sourcery

Introduce the `Array.Unshift` type helper to the Array namespace for prepending elements to tuple types, and register corresponding tests and changelog updates

New Features:
- Add `Array.Unshift<Arr, E>` type to prepend an element to tuple types

Documentation:
- Fix changelog date formatting and add an entry for `Array.Unshift`

Tests:
- Add type-level tests for `Array.Unshift` in `lib-Array.test.ts` and update the `lib-gen` script for its test cases